### PR TITLE
Vector: Minor improvements

### DIFF
--- a/FlappyBirdClone/include/Utils.h
+++ b/FlappyBirdClone/include/Utils.h
@@ -10,7 +10,7 @@ namespace utils
 	
 	inline float HireTimeInSeconds()
 	{
-		float t = SDL_GetTicks();
+		float t = (float)SDL_GetTicks();
 		t *= 0.001f;
 		return t;
 	}
@@ -18,7 +18,7 @@ namespace utils
 	inline void GetFramesRate()
 	{
 		fps++;
-		startTime = SDL_GetTicks();
+		startTime = (float)SDL_GetTicks();
 
 		if ((startTime - currentTime) > 1000.0f)
 		{

--- a/FlappyBirdClone/include/Vector.h
+++ b/FlappyBirdClone/include/Vector.h
@@ -2,21 +2,61 @@
 
 class Vector
 {
-private:
-	float x, y;
 public:
-	Vector();
+	Vector() = default;
 	Vector(float p_x, float p_y);
+
+	// Returns the x component.
+	float GetX() const;
+
+	// Sets the x component.
 	void SetX(float value);
+
+	// Returns the y component.
+	float GetY() const;
+
+	// Sets the x component.
 	void SetY(float value);
-	float GetX();
-	float GetY();
+
+	// Returns the angle.
+	float GetAngle() const;
+
+	// Sets the angle.
 	void SetAngle(float angle);
-	float GetAngle();
+
+	// Returns the length.
+	float GetLength() const;
+
+	// Sets the length.
 	void SetLength(float len);
-	float GetLength();
-	void AddTo(Vector v);
-	void SubTo(Vector v);
-	void MulTo(float val);
-	void DivTo(float val);
+
+	// Adds given vector to current.
+	void AddTo(const Vector &v);
+
+	// Subtracts given vector from current.
+	void SubTo(const Vector &v);
+
+	// Scales vector by given factor equally.
+	void Scale(float factor);
+
+	// Scales vector by given x and y factors along both components.
+	void Scale(float x, float y);
+
+	// Finds the dot product of current and other vector.
+	float Dot(const Vector& other) const;
+
+	Vector& Unitize();
+
+	Vector Unit() const;
+
+	// Returns addition of other and current vector.
+	Vector operator+(const Vector& other) const;
+
+	// Returns subtraction of other vector and from current vector.
+	Vector operator-(const Vector& other) const;
+
+private:
+	// Saves us from having a default constructor.
+	float x = 0.f;
+	float y = 0.f;
 };

--- a/FlappyBirdClone/src/Bird.cpp
+++ b/FlappyBirdClone/src/Bird.cpp
@@ -9,11 +9,11 @@ Bird::Bird(Vector p_pos, SDL_Texture* p_texture)
 
 void Bird::Update()
 {
-	if (velocity.GetY() <= 1.2)
+	if (velocity.GetY() <= 1.2f)
 		velocity.AddTo(gravity);
 
-	if (velocity.GetY() > 1.2)
-		velocity.SetY(1.2);
+	if (velocity.GetY() > 1.2f)
+		velocity.SetY(1.2f);
 
 	SetPosition(Vector(25, GetPosition().GetY() + velocity.GetY()));
 

--- a/FlappyBirdClone/src/Main.cpp
+++ b/FlappyBirdClone/src/Main.cpp
@@ -86,22 +86,22 @@ bool load = Init();
 
 
 Pipe pipe_down[4] = {
-	Pipe(Vector(70, utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down), //down = 180 150
-	Pipe(Vector(140, utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down),
-	Pipe(Vector(210, utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down),
-	Pipe(Vector(280, utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down)
+	Pipe(Vector(70.f, (float)utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down), //down = 180 150
+	Pipe(Vector(140.f, (float)utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down),
+	Pipe(Vector(210.f, (float)utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down),
+	Pipe(Vector(280.f, (float)utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)), pipeTexture_down)
 };
 
 Pipe pipe_up[4] = {
-	Pipe(Vector(70, utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up), //up = -50, -20
-	Pipe(Vector(140, utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up),
-	Pipe(Vector(210, utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up),
-	Pipe(Vector(280, utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up)
+	Pipe(Vector(70.f, (float)utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up), //up = -50, -20
+	Pipe(Vector(140.f, (float)utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up),
+	Pipe(Vector(210.f, (float)utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up),
+	Pipe(Vector(280.f, (float)utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)), pipeTexture_up)
 };
 
 Ground ground[2] = {
-	Ground(Vector(0, 200), groundTexture),
-	Ground(Vector(154, 200), groundTexture)
+	Ground(Vector(0.f, 200.f), groundTexture),
+	Ground(Vector(154.f, 200.f), groundTexture)
 };
 
 Bird bird(Vector(25, 96), birdtexture[0]);
@@ -111,19 +111,19 @@ void GameLoop()
 {
 
 	// pipe random generation
-	srand(time(0));
+	srand((unsigned int)time(0));
 
 	for (num = 0; num < 4; num++)
 	{
 		if (pipe_up[num].pipeCrossed)
 		{
-			pipe_up[num].SetPosition(Vector(pipe_up[num].GetPosition().GetX(), utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)));
+			pipe_up[num].SetPosition(Vector(pipe_up[num].GetPosition().GetX(), (float)utils::RandomValues(PIPE_UP_MAX_Y, PIPE_UP_MIN_Y)));
 			pipe_up[num].pipeCrossed = false;
 		}
 
 		if (pipe_down[num].pipeCrossed)
 		{
-			pipe_down[num].SetPosition(Vector(pipe_down[num].GetPosition().GetX(), utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)));
+			pipe_down[num].SetPosition(Vector(pipe_down[num].GetPosition().GetX(), (float)utils::RandomValues(PIPE_DOWN_MAX_Y, PIPE_DOWN_MIN_Y)));
 			pipe_down[num].pipeCrossed = false;
 		}
 	}
@@ -224,7 +224,6 @@ void GameLoop()
 
 int main(int argc, char* args[])
 {
-
 	while (gameRunning)
 	{
 		GameLoop();

--- a/FlappyBirdClone/src/RenderWindow.cpp
+++ b/FlappyBirdClone/src/RenderWindow.cpp
@@ -4,7 +4,7 @@
 
 void RenderWindow::CreateWindow(const char* p_title, float p_w, float p_h)
 {
-	window = SDL_CreateWindow(p_title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, p_w, p_h, SDL_WINDOW_SHOWN);
+	window = SDL_CreateWindow(p_title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, (int)p_w, (int)p_h, SDL_WINDOW_SHOWN);
 
 	if (window == NULL)
 		std::cout << "Window failed to load. ERROR: " << SDL_GetError() << std::endl;
@@ -43,10 +43,10 @@ void RenderWindow::Render(Entity& p_entity)
 	src.h = p_entity.GetCurrentFrame().h;
 
 	SDL_Rect dst;
-	dst.x = p_entity.GetPosition().GetX() * multiplier;
-	dst.y = p_entity.GetPosition().GetY() * multiplier;
-	dst.w = p_entity.GetCurrentFrame().w * multiplier;
-	dst.h = p_entity.GetCurrentFrame().h * multiplier;
+	dst.x = (int)p_entity.GetPosition().GetX() * multiplier;
+	dst.y = (int)p_entity.GetPosition().GetY() * multiplier;
+	dst.w = (int)p_entity.GetCurrentFrame().w * multiplier;
+	dst.h = (int)p_entity.GetCurrentFrame().h * multiplier;
 
 	SDL_RenderCopy(renderer, p_entity.GetTexture(), &src, &dst);
 }
@@ -59,10 +59,10 @@ void RenderWindow::Render(SDL_Texture* p_tex, Vector p_pos)
 	SDL_QueryTexture(p_tex, NULL, NULL, &src.w, &src.h);
 
 	SDL_Rect dst;
-	dst.x = p_pos.GetX() * multiplier;
-	dst.y = p_pos.GetY() * multiplier;
-	dst.w = src.w * multiplier;
-	dst.h = src.h * multiplier;
+	dst.x = (int)p_pos.GetX() * multiplier;
+	dst.y = (int)p_pos.GetY() * multiplier;
+	dst.w = (int)src.w * multiplier;
+	dst.h = (int)src.h * multiplier;
 
 	SDL_RenderCopy(renderer, p_tex, &src, &dst);
 }
@@ -76,10 +76,10 @@ void RenderWindow::Render(Entity& p_entity, Vector p_pos)
 	src.h = p_entity.GetCurrentFrame().h;
 
 	SDL_Rect dst;
-	dst.x = p_pos.GetX() * multiplier;
-	dst.y = p_pos.GetY() * multiplier;
-	dst.w = p_entity.GetCurrentFrame().w * multiplier;
-	dst.h = p_entity.GetCurrentFrame().h * multiplier;
+	dst.x = (int)p_pos.GetX() * multiplier;
+	dst.y = (int)p_pos.GetY() * multiplier;
+	dst.w = (int)p_entity.GetCurrentFrame().w * multiplier;
+	dst.h = (int)p_entity.GetCurrentFrame().h * multiplier;
 
 	SDL_RenderCopy(renderer, p_entity.GetTexture(), &src, &dst);
 }
@@ -92,8 +92,8 @@ void RenderWindow::RenderRotate(SDL_Texture* p_tex, Vector p_pos, float angle)
 	SDL_QueryTexture(p_tex, NULL, NULL, &src.w, &src.h);
 
 	SDL_Rect dst;
-	dst.x = p_pos.GetX() * multiplier;
-	dst.y = p_pos.GetY() * multiplier;
+	dst.x = (int)p_pos.GetX() * multiplier;
+	dst.y = (int)p_pos.GetY() * multiplier;
 	dst.w = src.w * multiplier;
 	dst.h = src.h * multiplier;
 

--- a/FlappyBirdClone/src/Vector.cpp
+++ b/FlappyBirdClone/src/Vector.cpp
@@ -4,18 +4,14 @@
 
 // degrees = (radians * 180) / pi
 
-#include<math.h>
+#include <cmath>
 
-#include"Vector.h"
-
-
-Vector::Vector()
-	:x(0.0f), y(0.0f)
-{}
+#include "Vector.h"
 
 Vector::Vector(float p_x, float p_y)
-	:x(p_x), y(p_y)
-{}
+	: x(p_x), y(p_y)
+{
+}
 
 void Vector::SetX(float value)
 {
@@ -27,12 +23,12 @@ void Vector::SetY(float value)
 	y = value;
 }
 
-float Vector::GetX()
+float Vector::GetX() const
 {
 	return x;
 }
 
-float Vector::GetY()
+float Vector::GetY() const
 {
 	return y;
 }
@@ -40,47 +36,86 @@ float Vector::GetY()
 void Vector::SetAngle(float angle)
 {
 	float length = GetLength();
-	x = cos(angle) * length;
-	y = sin(angle) * length;
+	x = std::cos(angle) * length;
+	y = std::sin(angle) * length;
 }
 
-float Vector::GetAngle()
+float Vector::GetAngle() const
 {
-	return atan2(y, x);
+	return std::atan2(y, x);
 }
 
 void Vector::SetLength(float len)
 {
 	float angle = GetAngle();
-	x = cos(angle) * len;
-	y = sin(angle) * len;
+	x = std::cos(angle) * len;
+	y = std::sin(angle) * len;
 }
 
-float Vector::GetLength()
+float Vector::GetLength() const
 {
-	return sqrt((double)x * x + (double)y * y);
+	return std::sqrt(x * x + y * y);
 }
 
-void Vector::AddTo(Vector v)
+void Vector::AddTo(const Vector &v)
 {
 	x += v.x;
 	y += v.y;
 }
 
-void Vector::SubTo(Vector v)
+void Vector::SubTo(const Vector &v)
 {
 	x -= v.x;
 	y -= v.y;
 }
 
-void Vector::MulTo(float val)
+void Vector::Scale(float factor)
 {
-	x *= val;
-	y *= val;
+	x *= factor;
+	y *= factor;
 }
 
-void Vector::DivTo(float val)
+void Vector::Scale(float x, float y)
 {
-	x /= val;
-	y /= val;
+	x *= x;
+	y *= y;
+}
+
+float Vector::Dot(const Vector& other) const
+{
+	return (x * other.x + y * other.y);
+}
+
+Vector& Vector::Unitize()
+{
+	auto mag = GetLength();
+	if (mag != 0)
+	{
+		x /= mag;
+		y /= mag;
+	}
+	return *this;
+}
+
+Vector Vector::Unit() const
+{
+	auto mag = GetLength();
+	if (mag == 0)
+	{
+		return Vector();
+	}
+	else
+	{
+		return Vector(x/mag, y/mag);
+	}
+}
+
+Vector Vector::operator+(const Vector& other) const
+{
+	return Vector(x + other.x, y + other.y);
+}
+
+Vector Vector::operator-(const Vector& other) const
+{
+	return Vector(x - other.x, y - other.y);
 }


### PR DESCRIPTION
Things modified:
- Fixed type conversion related warnings.
- Added default keyword for Vector() and initialized members to 0.f within the class.
- Added comments for all the method of Vector class.
- Made all the getter method const. Allows us to call them on const object of Vector.
- Changed parameters for some method to const reference. Avoid unnecessary copy constructions.
- Renamed MulTo() and DivTo() to Scale().

Added methods
- Scale() to scale the vector unevenly.
- Dot() to calculate dot product.
- Unitize(). Make the vector unit vector.
- Unit(). Returns a unit vector without modifying current vector.
- operator+(). Returns addition of two vectors.
- operator-(). Returns subtraction of two vectors.